### PR TITLE
Fixed because I was concerned about blank spaces etc

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLink
-    class="flex flex-col items-center bg-white border border-gray-200 rounded-lg shadow md:flex-row md:max-w-xl hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+    class="flex flex-col items-center bg-white border border-gray-200 rounded-lg shadow md:flex-row hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
     :to="props.path"
   >
     <img
@@ -8,7 +8,7 @@
       :src="props.image ? `thumbnails/${props.image}` : 'wed-logo.png'"
       :alt="props.title"
     />
-    <div class="flex flex-col justify-between p-4 leading-normal">
+    <div class="p-4 w-full leading-normal">
       <h5
         class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white"
       >

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,8 @@
 <template>
-  <div>
-    <p class="text-3xl font-bold underline">WED Engineering Team Blog</p>
+  <header>
+    <p class="text-3xl font-bold underline mb-8 p-3">WED Engineering Team Blog</p>
+  </header>
+  <div class="container mx-auto px-4 sm:px-0">
     <slot />
   </div>
 </template>

--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -1,6 +1,6 @@
 <template>
   <main>
-    <article class="prose">
+    <article class="prose max-w-full">
       <ContentRenderer v-if="data" :value="data" />
     </article>
   </main>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,8 +1,8 @@
 <template>
   <main>
     <ContentList v-slot="{ list }" :query="query">
-      <ul v-for="article in list" :key="article._path">
-        <li>
+      <ul>
+        <li v-for="article in list" :key="article._path" class="mb-8">
           <Card
             :title="article.title"
             :description="article.description"


### PR DESCRIPTION
余白など入れて見た目を調整してみました

## やったこと
* containerを設定
* リストやコンテンツにmarginを入れてコンテンツが画面端やカードごとにくっつかないようにした

<details><summary>PC index</summary>
<p>

<img width="846" alt="スクリーンショット 2023-11-05 14 52 22" src="https://github.com/wedinc/wedinc.github.io/assets/14311071/727c6095-6077-4442-bf31-28362d27f822">


</p>
</details> 

<details><summary>SP index</summary>
<p>

<img width="482" alt="スクリーンショット 2023-11-05 14 52 46" src="https://github.com/wedinc/wedinc.github.io/assets/14311071/7701db3d-e4a9-48f9-b0e2-03c5acb12cff">


</p>
</details> 

<details><summary>PC content</summary>
<p>

<img width="1062" alt="スクリーンショット 2023-11-05 14 59 19" src="https://github.com/wedinc/wedinc.github.io/assets/14311071/d9f3a611-f39a-4ce1-9d7d-36e30781cdfa">


</p>
</details> 

<details><summary>SP content</summary>
<p>


<img width="461" alt="スクリーンショット 2023-11-05 14 52 54" src="https://github.com/wedinc/wedinc.github.io/assets/14311071/91eb9114-4196-48a2-8f1e-2cceca2d1f99">

</p>
</details> 

