### PR TITLE
style(fix): hide pseudo class, content none

### DIFF
--- a/components/content/ProseCode.vue
+++ b/components/content/ProseCode.vue
@@ -27,10 +27,3 @@
     copy(props.code)
   }
 </script>
-
-<style scoped>
-  code::before,
-  code::after {
-    content: none;
-  }
-</style>

--- a/components/content/ProseCode.vue
+++ b/components/content/ProseCode.vue
@@ -27,3 +27,10 @@
     copy(props.code)
   }
 </script>
+
+<style scoped>
+  code::before,
+  code::after {
+    content: none;
+  }
+</style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,20 @@
 export default {
   content: [],
   theme: {
-    extend: {}
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            'code::before': {
+              content: '""'
+            },
+            'code::after': {
+              content: '""'
+            }
+          }
+        }
+      }
+    }
   },
   plugins: [require('@tailwindcss/typography')]
 }


### PR DESCRIPTION
code の擬似クラスの before, after に
変な Style が当たってたので、修正

https://github.com/tailwindlabs/tailwindcss-typography/issues/18#issuecomment-733045571 を参考に修正

**修正前**

<img width="784" alt="image" src="https://github.com/wedinc/wedinc.github.io/assets/43776161/322b88f4-7c4e-44ec-b73d-c8220c56eff3">

**修正後**
<img width="735" alt="image" src="https://github.com/wedinc/wedinc.github.io/assets/43776161/f8aaa2c0-9ec3-4eb3-b29e-dbfd0682856d">

---
Plugin 側も一応修正投げてます https://github.com/tailwindlabs/tailwindcss-typography/pull/328