### PR TITLE
tailwind の css Theme 入れたら code block の色が変なことになったので修正

### DIFF
--- a/components/content/ProseCode.vue
+++ b/components/content/ProseCode.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="prose-code relative">
+  <code class="prose-code relative">
     <slot />
     <img
       src="@/assets/images/copy.svg"
       class="copy-btn absolute w-7 top-2 right-2 bg-gray-600 hover:bg-gray-500 rounded-xl p-0.5 box-content transition-colors cursor-pointer m-0"
       @click="onClick"
     />
-  </div>
+  </code>
 </template>
 
 <script setup lang="ts">

--- a/components/content/ProseCode.vue
+++ b/components/content/ProseCode.vue
@@ -1,14 +1,12 @@
 <template>
-  <code
-    class="text-sm sm:text-base inline-flex text-left items-center space-x-4 bg-gray-900 text-white rounded-lg p-4 pl-6 relative w-full"
-  >
+  <div class="prose-code relative">
     <slot />
     <img
       src="@/assets/images/copy.svg"
-      class="absolute w-7 top-2 right-2 bg-gray-600 hover:bg-gray-500 rounded-xl p-1 box-content transition-colors cursor-pointer"
+      class="copy-btn absolute w-7 top-2 right-2 bg-gray-600 hover:bg-gray-500 rounded-xl p-0.5 box-content transition-colors cursor-pointer m-0"
       @click="onClick"
     />
-  </code>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -24,6 +22,6 @@
   const { copy } = useClipboard()
 
   const onClick = () => {
-    copy(props.code)
+    copy(props.code.slice(0, -1))
   }
 </script>


### PR DESCRIPTION
- style(fix): rm background color

タイトルの通り。
ついでに、Copy するときに必ず、空行が一行入っちゃうので、slice で最後の文字（改行コード）を削除するように修正

before
<img width="375" alt="image" src="https://github.com/wedinc/wedinc.github.io/assets/43776161/8f29b23b-9563-4e2b-a335-acfec0615bbc">

二重になっちゃってた

after
<img width="389" alt="image" src="https://github.com/wedinc/wedinc.github.io/assets/43776161/42c331ce-ee27-4134-99a5-7446fb4ee0d1">

