### PR TITLE
ブログコンテンツの中ではリンクは常に target="_blank" に

### DIFF
--- a/assets/images/link.svg
+++ b/assets/images/link.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Interface / External_Link">
+<path id="Vector" d="M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/components/content/ProseA.vue
+++ b/components/content/ProseA.vue
@@ -1,0 +1,25 @@
+<template>
+  <NuxtLink :href="href" :target="target" class="flex">
+    <slot />
+    <div>
+      <img
+        src="@/assets/images/link.svg"
+        class="w-3 m-0 ml-1 mb-1.5 inline align-bottom"
+      />
+    </div>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+  defineProps({
+    href: {
+      type: String,
+      default: ''
+    },
+    target: {
+      type: String,
+      default: '_blank',
+      required: false
+    }
+  })
+</script>


### PR DESCRIPTION
記事の中で埋め込む Link はほとんど外部リンク
（というより、読んでもらいたいブログなのに、タブのなかで画面遷移されると困る。）
なので、default で `target="_blank"` にするように

ついでに、外部リンクっぽい画像も入れてみた
