### PR TITLE
Resurrect index.md and exclude it from top page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,15 @@
+---
+title: 'Nuxt Content'
+description: 'meta description of the page'
+date: '2020-10-21'
+---
+
+# Nuxt Content
+
+This page corresponds to the `/` route of your website. You can delete it or create another file in the `content/` directory.
+
+Try to navigate to [/about](/about). These 2 pages are rendered by the `pages/[...slug].vue` component.
+
+---
+
+Look at the [Content documentation](https://content.nuxtjs.org/) to learn more.

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,5 +19,8 @@
 
 <script setup lang="ts">
   import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'
-  const query: QueryBuilderParams = { sort: [{ date: -1 }] }
+  const query: QueryBuilderParams = {
+    sort: [{ date: -1 }],
+    where: { _path: { $ne: '/' } }
+  }
 </script>


### PR DESCRIPTION
#59 でindex.mdを削除したところyarn generateが落ちるようになったので戻して、トップページの記事一覧に出ないようにした
(ローカルではyarn build使ってました:sumanai:)